### PR TITLE
Bugfix/issue 16 furo ui5 data select

### DIFF
--- a/mockdata/persons/list2.json
+++ b/mockdata/persons/list2.json
@@ -75,11 +75,30 @@
           "service": "PersonService"
         }
       ]
+    },
+    {
+      "data": {
+        "display_name": "Yaki Tasimoto, +41781442233",
+        "first_name": "Yaki",
+        "id": "5",
+        "name": "Tasimoto",
+        "phone_nr": "+41781442244",
+        "skills": []
+      },
+      "links": [
+        {
+          "href": "/mockdata/persons/5/get.json",
+          "method": "GET",
+          "rel": "self",
+          "type": "person.Person",
+          "service": "PersonService"
+        }
+      ]
     }
   ],
   "links": [
     {
-      "href": "/mockdata/persons/list2.json",
+      "href": "/mockdata/persons/list.json",
       "method": "GET",
       "rel": "list",
       "type": "person.PersonCollection",

--- a/packages/furo-ui5/demos/demo-furo-ui5-data-select.js
+++ b/packages/furo-ui5/demos/demo-furo-ui5-data-select.js
@@ -87,7 +87,7 @@ class DemoFuroUi5DataSelect extends FBP(LitElement) {
               >Load Demo Data
             </furo-ui5-button>
             <furo-ui5-button design="Neutral" @-click="--demoDataReloadRequest"
-            >Reload Demo Data
+              >Reload Demo Data
             </furo-ui5-button>
             <h4 full>furo-ui5-data-select without ANY type binding.</h4>
             <furo-ui5-form-field-container>

--- a/packages/furo-ui5/demos/demo-furo-ui5-data-select.js
+++ b/packages/furo-ui5/demos/demo-furo-ui5-data-select.js
@@ -82,9 +82,12 @@ class DemoFuroUi5DataSelect extends FBP(LitElement) {
       </h2>
       <furo-demo-snippet>
         <template>
-          <furo-form-layouter>
-            <furo-ui5-button full design="Emphasized" @-click="--demoDataRequested"
+          <furo-form-layouter two>
+            <furo-ui5-button design="Emphasized" @-click="--demoDataRequested"
               >Load Demo Data
+            </furo-ui5-button>
+            <furo-ui5-button design="Neutral" @-click="--demoDataReloadRequest"
+            >Reload Demo Data
             </furo-ui5-button>
             <h4 full>furo-ui5-data-select without ANY type binding.</h4>
             <furo-ui5-form-field-container>
@@ -329,6 +332,7 @@ class DemoFuroUi5DataSelect extends FBP(LitElement) {
           <furo-collection-agent
             service="PersonService"
             ƒ-hts-in="--htsPerson"
+            ƒ-list="--demoDataReloadRequest"
             list-on-hts-in
             @-response="--responseCollection"
           >

--- a/packages/furo-ui5/src/furo-ui5-data-select.js
+++ b/packages/furo-ui5/src/furo-ui5-data-select.js
@@ -448,10 +448,10 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
      * if there is an active field binding
      * the option should be re-selected
      */
-    if (this.activeFieldBinding){
-      setTimeout(()=>{
+    if (this.activeFieldBinding) {
+      setTimeout(() => {
         this.selectOptionById(this._tmpValue);
-      },0)
+      }, 0);
     }
 
     this.dispatchEvent(
@@ -513,6 +513,7 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
     if (this.activeFieldBinding) {
       if (this.isFat()) {
         if (newValue === '') {
+          this._tmpValue = null;
           this._tmpFAT.value = null;
           // add empty state
           if (this._tmpFAT.labels === null) {
@@ -520,6 +521,7 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
           }
           this._tmpFAT.labels.empty = true;
         } else {
+          this._tmpValue = newValue;
           this._tmpFAT.value = newValue;
           // remove empty state
           if (this._tmpFAT.labels && this._tmpFAT.labels.empty) {
@@ -534,8 +536,10 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
         }
         this.setFnaFieldValue(this._tmpFAT);
       } else if (this.isWrapper()) {
+        this._tmpValue = newValue === '' ? null : newValue;
         this.setFnaFieldValue(newValue === '' ? null : newValue);
       } else {
+        this._tmpValue = newValue;
         this.setFnaFieldValue(newValue === '' ? '' : newValue);
       }
     }

--- a/packages/furo-ui5/src/furo-ui5-data-select.js
+++ b/packages/furo-ui5/src/furo-ui5-data-select.js
@@ -202,12 +202,14 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
    */
   onFnaFieldValueChanged(val) {
     if (this.isFat()) {
-      this._tmpFAT = val;
-      this.selectOptionById(this._tmpFAT.value);
-      this._updateAttributesFromFat(this._tmpFAT.attributes);
-      this._updateLabelsFromFat(this._tmpFAT.labels);
+      this._fatValue = val;
+      this._tmpValue = this._fatValue.value;
+      this.selectOptionById(this._fatValue.value);
+      this._updateAttributesFromFat(this._fatValue.attributes);
+      this._updateLabelsFromFat(this._fatValue.labels);
     } else {
-      this.selectOptionById(val);
+      this._tmpValue = val;
+      this.selectOptionById(this._tmpValue);
     }
   }
 
@@ -438,9 +440,18 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
       });
 
       optionNodeList.forEach(newOpt => {
-        this.options.push(newOpt);
         this.appendChild(newOpt);
       });
+    }
+
+    /**
+     * if there is an active field binding
+     * the option should be re-selected
+     */
+    if (this.activeFieldBinding){
+      setTimeout(()=>{
+        this.selectOptionById(this._tmpValue);
+      },0)
     }
 
     this.dispatchEvent(


### PR DESCRIPTION
This bugfix solves the following issues:

- loading options **after** binding a field should select the correct option item
- **re-loading** of **options** should have **no effect** on the selection state (exception: id is no longer available)