### PR TITLE
fix: handling of oneOf FieldNodes. 

### DIFF
--- a/packages/furo-data/src/lib/DataObject.js
+++ b/packages/furo-data/src/lib/DataObject.js
@@ -77,7 +77,7 @@ export class DataObject extends EventTreeNode {
   }
 
   /**
-   * Injecten eines raw models wie bspw body oder entity einer collection
+   * injects a raw model e.g. body data of a collection or entity
    * @param rawEntity
    */
   injectRaw(rawEntity) {
@@ -244,7 +244,7 @@ export class DataObject extends EventTreeNode {
           }
         } else {
           // eslint-disable-next-line no-param-reassign
-          n._value = Helper.defaultForType(n._spec.type);
+          n._value = Helper.indeterminateDefault();
         }
       }
     });

--- a/packages/furo-data/src/lib/Helper.js
+++ b/packages/furo-data/src/lib/Helper.js
@@ -21,8 +21,12 @@ export class Helper {
       case 'sfixed64':
         return 0;
       default:
-        return undefined;
+        return null;
     }
+  }
+
+  static indeterminateDefault() {
+    return null;
   }
 
   /**

--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -156,6 +156,13 @@ export class RepeaterNode extends EventTreeNode {
   }
 
   /**
+   * removes all children
+   */
+  reset() {
+    this.removeAllChildren();
+  }
+
+  /**
    * deletes all repeated fields on this node
    */
   removeAllChildren() {

--- a/packages/furo-data/test/FieldNodesDefaults.test.js
+++ b/packages/furo-data/test/FieldNodesDefaults.test.js
@@ -30,15 +30,16 @@ describe('FieldNodesDefaults', () => {
     assert.equal(element.nodeName.toLowerCase(), 'furo-data-object');
     done();
   });
-  it('should set the defaults like protobuf', done => {
+
+  it('should set indeterminate default value', done => {
     element.setAttribute('type', 'experiment.Experiment');
 
     const handler = () => {
-      assert.equal(element.data.description._value, '');
-      assert.equal(element.data.furo_data_checkbox_input._value, false);
+      assert.equal(element.data.description._value, null);
+      assert.equal(element.data.furo_data_checkbox_input._value, null);
 
-      assert.equal(element.data.furo_data_date_input_google._value.year === 0, true);
-      assert.equal(element.data.furo_data_date_input_google._value.month === 0, true);
+      assert.equal(element.data.furo_data_date_input_google._value.year, null);
+      assert.equal(element.data.furo_data_date_input_google._value.month, null);
 
       done();
     };
@@ -55,8 +56,8 @@ describe('FieldNodesDefaults', () => {
       element.data.furo_data_date_input_google.reset();
       assert.equal(element.data.description._value, null);
 
-      assert.equal(element.data.furo_data_date_input_google._value.year === null, true);
-      assert.equal(element.data.furo_data_date_input_google._value.month === null, true);
+      assert.equal(element.data.furo_data_date_input_google._value.year, null);
+      assert.equal(element.data.furo_data_date_input_google._value.month, null);
 
       done();
     };

--- a/packages/furo-data/test/furo-data-object.test.js
+++ b/packages/furo-data/test/furo-data-object.test.js
@@ -192,35 +192,29 @@ describe('furo-data-object', () => {
   it('should be possible to reset to last injected state', done => {
     element.setAttribute('type', 'project.ProjectEntity');
 
+    const handler = () => {
+      assert.equal(element.json.data.display_name,"Furo Foundation, CHF 150'000.00");
+      done();
+    };
+
     fetch('/mockdata/projects/1/testmeta.json')
       .then(res => res.json())
       .then(response => {
         element.injectRaw(response);
-
-        assert.equal(element.json.data.display_name, response.data.display_name);
-
-        done();
+        element.data.data.display_name._value = "changed value";
+        element.data.addEventListener('data-injected', handler, { once: true });
+        element.reset();
       });
-  });
-
-  it('should validate a fieldnode against the specs', done => {
-    element.setAttribute('type', 'experiment.Experiment');
-    // assert.equal(element.data.furo_data_text_input._value, "Ein text per default");
-    const handler = () => {
-      assert.equal(element.data.furo_data_text_input._value, '');
-      assert.equal(element.data.furo_data_text_input._pristine, true);
-      done();
-    };
-    element.data.addEventListener('data-injected', handler, { once: true });
-
-    element.injectRaw({ id: 12, display_name: 'party' });
   });
 
   it('should set the values like injected, remove defaults,...', done => {
     element.setAttribute('type', 'experiment.Default');
     assert.equal(element.data.description._value, 'Ein text per default');
     const handler = () => {
-      assert.equal(element.data.description._value, '');
+      assert.equal(element.data.description._value, null);
+      assert.equal(element.data.display_name._value, 'party');
+      assert.equal(element.data.furo_data_checkbox_input._pristine, true);
+      assert.equal(element.data.furo_data_checkbox_input._value, null);
       done();
     };
     element.data.addEventListener('data-injected', handler, { once: true });
@@ -236,7 +230,7 @@ describe('furo-data-object', () => {
 
     // after response inject
     const handler = () => {
-      assert.equal(element.data.data.description._value, '');
+      assert.equal(element.data.data.description._value, null);
       assert.equal(element.data.data.furo_data_checkbox_input._meta.label, 'Label from response');
       assert.equal(element.data.data.furo_data_checkbox_input._meta.readonly, true);
       done();

--- a/packages/furo-data/test/furo-oneof.test.js
+++ b/packages/furo-data/test/furo-oneof.test.js
@@ -49,9 +49,11 @@ describe('furo data oneof', () => {
 
     EntityRoot.furo_data_checkbox_input._value = true;
     EntityRoot.display_name._value = 'Some Text';
+    assert.equal(EntityRoot.furo_data_checkbox_input._value, null);
+
     EntityRoot.furo_data_checkbox_input._value = false;
-    assert.equal(EntityRoot.display_name._value, '');
     assert.equal(EntityRoot.furo_data_checkbox_input._value, false);
+    assert.equal(EntityRoot.display_name._value, null);
 
     done();
   });
@@ -70,7 +72,8 @@ describe('furo data oneof', () => {
     const jsonval = EntityRoot.getJson();
 
     // eslint-disable-next-line no-prototype-builtins
-    assert.equal(JSON.parse(JSON.stringify(jsonval)).hasOwnProperty('update_mask'), false);
+    assert.equal(JSON.parse(JSON.stringify(jsonval)).hasOwnProperty('update_mask'), true);
+    assert.equal(jsonval.update_mask, null);
     done();
   });
 

--- a/packages/furo-ui5/demos/demo-furo-ui5-button-bar.js
+++ b/packages/furo-ui5/demos/demo-furo-ui5-button-bar.js
@@ -52,6 +52,7 @@ class DemoFuroUi5ButtonBar extends FBP(LitElement) {
     super._FBPReady();
     // this._FBPTraceWires()
     this._FBPTriggerWire('--qpIn', { query: { tsk: 1 } });
+
   }
 
   /**


### PR DESCRIPTION
This PR changes the behaviour of setting default values to FieldNodes. Additional changes for FieldNodes inside of an oneOf definition.

**Default Values**
1. Default value from API Spec
2. if no default, set indeterminate value instead of defaultForType (Proto defaults)

**OneOf Rules:**
- Check if FieldNode is part of an oneOf definition.
- Check if FieldNode has data. 
- Set data and reset all other fields of the oneOf definition
- No data, no action