### PR TITLE
Use of filter with furo-ui5-data-reference-search

### DIFF
--- a/packages/furo-ui5/src/furo-ui5-data-reference-search-labeled.js
+++ b/packages/furo-ui5/src/furo-ui5-data-reference-search-labeled.js
@@ -139,6 +139,14 @@ export class FuroUi5DataReferenceSearchLabeled extends FBP(LitElement) {
   }
 
   /**
+   * sets the filter to the inner furo-ui5-data-reference-search
+   * @param filter
+   */
+  setFilter(filter) {
+    this._FBPTriggerWire('--filter', filter);
+  }
+
+  /**
    * @private
    * @returns {TemplateResult|TemplateResult}
    */
@@ -165,6 +173,7 @@ export class FuroUi5DataReferenceSearchLabeled extends FBP(LitElement) {
           extended-display-field-path="${this.extendedDisplayFieldPath}"
           ƒ-bind-data="--data"
           ƒ-focus="--focus"
+          ƒ-set-filter="--filter"
         ></furo-ui5-data-reference-search>
       </furo-ui5-form-field-container>
     `;

--- a/packages/furo-ui5/src/furo-ui5-data-reference-search.js
+++ b/packages/furo-ui5/src/furo-ui5-data-reference-search.js
@@ -177,9 +177,9 @@ export class FuroUi5DataReferenceSearch extends FBP(FieldNodeAdapter(LitElement)
     if (this.__fieldNode.__childNodes.length === 0) {
       // assuming a scalar
       this.value = { id: val, display_name: val };
-      this._FBPTriggerWire('--displayValue', val || "");
+      this._FBPTriggerWire('--displayValue', val || '');
     } else {
-      this._FBPTriggerWire('--displayValue', val.display_name || "");
+      this._FBPTriggerWire('--displayValue', val.display_name || '');
       this.value = val;
     }
 
@@ -898,6 +898,17 @@ export class FuroUi5DataReferenceSearch extends FBP(FieldNodeAdapter(LitElement)
   }
 
   /**
+   * Sets the filter.
+   * Hint: use the FieldNode._base64 property to send complex objects as a filter and decode it on the server side
+   * or do btoa(JSON.stringify(FILTER))
+   *
+   * @param filter
+   */
+  setFilter(filter) {
+    this._FBPTriggerWire('--filter', filter);
+  }
+
+  /**
    * Themable Styles
    * @private
    * @return {CSSResult}
@@ -1042,6 +1053,7 @@ export class FuroUi5DataReferenceSearch extends FBP(FieldNodeAdapter(LitElement)
       <!-- todo: ƒ-cancel-request="--searchTerm" -->
       <furo-collection-agent
         ƒ-.service="--detectedService, |--service"
+        ƒ-set-filter="--filter"
         ƒ-search="--debouncedSrch"
         ƒ-next="--loadMore"
         page-size="${this.maxItemsToDisplay}"


### PR DESCRIPTION
furo-ui5-data-reference-search can receive a filter that is delegated to the inner api agent.

With this extension, several reference searchers can be connected in order to limit the search with the selection of the preceding element.

**Use case**
select country, then select city from country, then select address from city

`
<furo-ui5-data-reference-search-country @-item-selected="--countrySelected">
</furo-ui5-data-reference-search>

<furo-ui5-data-reference-search-city ƒ-set-filter="--countrySelected" @-item-selected="--citySelected">
</furo-ui5-data-reference-search>

<furo-ui5-data-reference-search-address ƒ-set-filter="--citySelected" @-item-selected="--addressSelected">
</furo-ui5-data-reference-search>
`
The api request will have a query param filter=VALUE_BASE64