### PR TITLE
FieldNode: wrong break criteria during for-in loop in meta

### DIFF
--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -575,16 +575,15 @@ export class FieldNode extends EventTreeNode {
           this[field].dispatchNodeEvent(new NodeEvent('this-metas-changed', this[field], false));
         }
 
-        // exit here, it does not go deeper
-        return;
-      }
-      const target = f[0];
-      const subMetaAndConstraints = { fields: {} };
-      subMetaAndConstraints.fields[f.slice(1).join('.')] = mc;
-      // eslint-disable-next-line no-param-reassign
-      level += 1;
+      } else {
+        const target = f[0];
+        const subMetaAndConstraints = { fields: {} };
+        subMetaAndConstraints.fields[f.slice(1).join('.')] = mc;
+        // eslint-disable-next-line no-param-reassign
+        level += 1;
 
-      this[target].__updateMetaAndConstraints(subMetaAndConstraints, level);
+        this[target].__updateMetaAndConstraints(subMetaAndConstraints, level);
+      }
     }
   }
 


### PR DESCRIPTION
**Problem description**
If you add more than one meta field on the level of a FieldNode, only the first meta information is set in the data object. This is because the break criteria of the loop was wrong.

**Test data**
`[
      {
        "id": "afd74a32-dda7-4b99-8d75-918cf50130ee",
        "display_name": "Rabattschutz",
        "data": {
          "@type": "type.googleapis.com/furo.StringOptionProperty",
          "display_name": "Ja",
          "id": "-2010024625"
        },
        "meta": {
          "fields": {
            "data": {
              "meta": {
                "label": "Rabattschutz",
                "options": {
                  "list": [
                    {
                      "@type": "furo.Optionitem",
                      "id": "-2010024624",
                      "display_name": "Nein"
                    },
                    {
                      "@type": "furo.Optionitem",
                      "id": "-2010024625",
                      "display_name": "Ja"
                    }
                  ]
                }
              },
              "constraints": {
                "required": {
                  "is": "true",
                  "message": "Bitte ausfüllen!"
                }
              }
            },
            "is_overwritten": {
              "meta": {
                "label": "Custom Label Prop Checkbox",
                "placeholder": "Custom placeholder",
                "readonly": true
              }
            }
          }
        },
        "code": "75cd8271-3f62-4f5f-a070-d850863f4079",
        "is_overwritten": false,
        "flags": [
          "is-overwritable"
        ]
      }]`

As you can see, on the root level of the FieldNode is an attribute `meta` with 2 fields (data and is_overwritten).
![Screenshot 2021-12-15 at 15 05 45](https://user-images.githubusercontent.com/9052672/146201051-18b64e4d-897a-466e-bfde-81a9a0aec3bb.png)

