### PR TITLE
fix: custom value state message handling and default messages from SAP

### DIFF
--- a/packages/furo-ui5/src/furo-ui5-data-date-picker.js
+++ b/packages/furo-ui5/src/furo-ui5-data-date-picker.js
@@ -184,17 +184,35 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DatePicker.default) 
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -236,24 +254,33 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DatePicker.default) 
   }
 
   /**
-   * update the value state and the value state message on demand
+   * updates the value state and the value state message on demand
    *
    * @param valueState
    * @param message
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
+++ b/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
@@ -157,17 +157,35 @@ export class FuroUi5DataDateTimePicker extends FieldNodeAdapter(DateTimePicker.d
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -210,17 +228,26 @@ export class FuroUi5DataDateTimePicker extends FieldNodeAdapter(DateTimePicker.d
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-multi-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-multi-input.js
@@ -92,17 +92,35 @@ export class FuroUi5DataMultiInput extends FieldNodeAdapter(MultiInput.default) 
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -171,6 +189,8 @@ export class FuroUi5DataMultiInput extends FieldNodeAdapter(MultiInput.default) 
     if (validity.description) {
       // this value state should not be saved as a previous value state
       this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
     }
   }
 
@@ -190,17 +210,26 @@ export class FuroUi5DataMultiInput extends FieldNodeAdapter(MultiInput.default) 
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-number-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-number-input.js
@@ -105,17 +105,35 @@ export class FuroUi5DataNumberInput extends FieldNodeAdapter(Input.default) {
     this.type = 'Number';
 
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -420,6 +438,8 @@ export class FuroUi5DataNumberInput extends FieldNodeAdapter(Input.default) {
     if (validity.description) {
       // this value state should not be saved as a previous value state
       this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
     }
   }
 
@@ -506,24 +526,33 @@ export class FuroUi5DataNumberInput extends FieldNodeAdapter(Input.default) {
   }
 
   /**
-   * update the value state and the value state message on demand
+   * updates the value state and the value state message on demand
    *
    * @param valueState
    * @param message
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-password-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-password-input.js
@@ -117,17 +117,35 @@ export class FuroUi5PasswordInput extends FieldNodeAdapter(Input.default) {
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -449,6 +467,8 @@ export class FuroUi5PasswordInput extends FieldNodeAdapter(Input.default) {
     if (validity.description) {
       // this value state should not be saved as a previous value state
       this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
     }
   }
 
@@ -542,17 +562,26 @@ export class FuroUi5PasswordInput extends FieldNodeAdapter(Input.default) {
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-select.js
+++ b/packages/furo-ui5/src/furo-ui5-data-select.js
@@ -142,18 +142,6 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
     }
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
-
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('*[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
-    }
   }
 
   /**
@@ -289,19 +277,21 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
   }
 
   /**
-   * overwrite onFnaFieldNodeBecameInvalid function
+   * Overridden onFnaFieldNodeBecameInvalid function
    * @private
    * @param validity
    */
   onFnaFieldNodeBecameInvalid(validity) {
-    // if (validity.description) {
-    // this value state should not be saved as a previous value state
-    this._setValueStateMessage('Error', validity.description);
-    // }
+    if (validity.description) {
+      // this value state should not be saved as a previous value state
+      this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
+    }
   }
 
   /**
-   * overwrite onFnaFieldNodeBecameValid function
+   * Overridden onFnaFieldNodeBecameValid function
    * @private
    */
   onFnaFieldNodeBecameValid() {
@@ -407,6 +397,36 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
   }
 
   /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
+    }
+  }
+
+  /**
    * update the value state and the value state message on demand
    *
    * @param valueState
@@ -414,19 +434,26 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    if (message !== undefined) {
-      // element was created in constructor
-      this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
     }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**
@@ -584,7 +611,7 @@ export class FuroUi5DataSelect extends FieldNodeAdapter(Select.default) {
         this._tmpValue = newValue === '' ? null : newValue;
         this.setFnaFieldValue(newValue === '' ? null : newValue);
       } else if (this.getDataType() === 'furo.StringOptionProperty') {
-        const strOpt = {id: newValue, display_name: selectedOption.textContent}
+        const strOpt = { id: newValue, display_name: selectedOption.textContent };
         this.setFnaFieldValue(strOpt);
         return;
       } else {

--- a/packages/furo-ui5/src/furo-ui5-data-text-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-text-input.js
@@ -117,17 +117,35 @@ export class FuroUi5DataTextInput extends FieldNodeAdapter(Input.default) {
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -449,6 +467,8 @@ export class FuroUi5DataTextInput extends FieldNodeAdapter(Input.default) {
     if (validity.description) {
       // this value state should not be saved as a previous value state
       this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
     }
   }
 
@@ -542,17 +562,26 @@ export class FuroUi5DataTextInput extends FieldNodeAdapter(Input.default) {
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**

--- a/packages/furo-ui5/src/furo-ui5-data-textarea-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-textarea-input.js
@@ -122,17 +122,35 @@ export class FuroUi5DataTextareaInput extends FieldNodeAdapter(TextArea.default)
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
@@ -416,6 +434,8 @@ export class FuroUi5DataTextareaInput extends FieldNodeAdapter(TextArea.default)
     if (validity.description) {
       // this value state should not be saved as a previous value state
       this._setValueStateMessage('Error', validity.description);
+    } else {
+      this.valueState = 'Error';
     }
   }
 
@@ -435,17 +455,39 @@ export class FuroUi5DataTextareaInput extends FieldNodeAdapter(TextArea.default)
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
+  }
+
+  /**
+   * @private
+   */
+  static get metadata() {
+    const md = super.metadata;
+    md.tag = 'furo-ui5-textarea-input';
+    return md;
+  }
+
+  static get styles() {
+    return super.styles;
   }
 }
 

--- a/packages/furo-ui5/src/furo-ui5-data-time-picker.js
+++ b/packages/furo-ui5/src/furo-ui5-data-time-picker.js
@@ -174,24 +174,51 @@ export class FuroUi5DataTimePicker extends FieldNodeAdapter(TimePicker.default) 
     }
   }
 
+  /**
+   * @private
+   */
   connectedCallback() {
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.readAttributes();
+  }
 
-    // created to avoid the default messages from ui5
-    const vse = this.querySelector('div[slot="valueStateMessage"]');
-    if (vse === null) {
-      this._valueStateElement = document.createElement('div');
-      this._valueStateElement.setAttribute('slot', 'valueStateMessage');
-      // eslint-disable-next-line wc/no-constructor-attributes
-      this.appendChild(this._valueStateElement);
-    } else {
-      this._valueStateElement = vse;
-      this._previousValueState.message = vse.innerText;
+  /**
+   * Adds a div with slot="valueStateMessage" to show
+   * field related information if the attribute value-state is set.
+   * @returns {HTMLDivElement}
+   * @private
+   */
+  _addValueStateMessage() {
+    const EXISTING_VSE = this.querySelector('div[slot="valueStateMessage"]');
+    if (EXISTING_VSE !== null) {
+      return EXISTING_VSE;
+    }
+    // we only create the ValueStateContainer if none already exists.
+    const VALUE_STATE_MESSAGE_ELEMENT = document.createElement('div');
+    VALUE_STATE_MESSAGE_ELEMENT.setAttribute('slot', 'valueStateMessage');
+    // eslint-disable-next-line wc/no-constructor-attributes
+    this.appendChild(VALUE_STATE_MESSAGE_ELEMENT);
+    return VALUE_STATE_MESSAGE_ELEMENT;
+  }
+
+  /**
+   * Removes <div slot="valueStateMessage"></div>
+   * @private
+   */
+  _removeValueStateMessage() {
+    const VALUE_STATE_MESSAGE_ELEMENT = this.querySelector('div[slot="valueStateMessage"]');
+    if (VALUE_STATE_MESSAGE_ELEMENT !== null) {
+      VALUE_STATE_MESSAGE_ELEMENT.remove();
     }
   }
 
+  /**
+   * Reads the attributes which are set on the component dom.
+   * those attributes can be set. `value-state`, `value-state-message`,  `icon`, `placeholder`, `required`,`readonly`,`disabled`
+   *
+   * Use this after manual or scripted update of the attributes.
+   */
   readAttributes() {
     this._previousValueState.state = this.getAttribute('value-state')
       ? this.getAttribute('value-state')
@@ -231,17 +258,26 @@ export class FuroUi5DataTimePicker extends FieldNodeAdapter(TimePicker.default) 
    * @private
    */
   _setValueStateMessage(valueState, message) {
+    const VSE = this._addValueStateMessage();
     this.valueState = valueState;
-    // element was created in constructor
-    this._valueStateElement.innerText = message;
+    if (VSE !== null) {
+      VSE.innerText = message || '';
+    }
   }
 
   /**
-   * reset to previous value state
+   * resets value-state and valueStateMessage to previous value state
+   * If no previous message is set, the valueStateMessage container is removed.
    * @private
    */
   _resetValueStateMessage() {
-    this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    this.valueState = this._previousValueState.state;
+
+    if (this._previousValueState?.message?.length) {
+      this._setValueStateMessage(this._previousValueState.state, this._previousValueState.message);
+    } else {
+      this._removeValueStateMessage();
+    }
   }
 
   /**


### PR DESCRIPTION
This fix will solve the following problems:

not showing standard SAP value state messages (localized)
it's possible to set a value state with message in every supported component (except value-state="Success", there is no message supported)