### PR TITLE
Alternative fbp "commands"

### DIFF
--- a/packages/furo-fbp/src/fbp.js
+++ b/packages/furo-fbp/src/fbp.js
@@ -464,7 +464,7 @@ export const FBP = superClass =>
           }
 
           // collect sending tags
-          if (element.attributes[i].name.startsWith('on-')) {
+          if (element.attributes[i].name.startsWith('at-')) {
             const eventname = element.attributes[i].name.substring(3);
             const fwires = element.attributes[i].value;
             fwires.split(',').forEach(fwire => {

--- a/packages/furo-fbp/test/fbp-fn-debugging.test.js
+++ b/packages/furo-fbp/test/fbp-fn-debugging.test.js
@@ -1,0 +1,74 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+import 'sinon/pkg/sinon.js';
+
+describe('fbp-fn-debugging.test', () => {
+  let element;
+  let host;
+  let receiver;
+  let sender;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <div id="hull">
+            <div id="sender" on-click="--data-received">sender</div>
+            <div id="receiver" fn-click="--data-received">receiver</div>
+          </div>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [, element] = testbind.parentNode.children;
+    receiver = element.querySelector('#receiver');
+    sender = element.querySelector('#sender');
+    await host.updateComplete;
+    await element.updateComplete;
+  });
+
+  it('should assign the correct elements', done => {
+    assert.equal(element.id, 'hull');
+    assert.equal(receiver.id, 'receiver');
+    assert.equal(sender.id, 'sender');
+    done();
+  });
+
+  it('should debug a wire', done => {
+    host._FBPDebug('--data-received');
+
+    // "spy" on `console.log()`
+    // eslint-disable-next-line no-undef
+    const spy = sinon.spy(console, 'log');
+    sender.click(9);
+    assert(spy.calledWith(0));
+
+    host._FBPTriggerWire('--data-received', 'data');
+    assert(spy.calledWith('data'));
+
+    // restore the original function
+    spy.restore();
+    done();
+  });
+
+  it('should debug a wire', done => {
+    host._FBPTraceWires();
+
+    // "spy" on `console.log()`
+    // eslint-disable-next-line no-undef
+    const spy = sinon.spy(console, 'log');
+    sender.click(9);
+    assert(spy.calledWith(0));
+
+    host._FBPTriggerWire('--data-received', 'data');
+    assert(spy.calledWith('data'));
+
+    // restore the original function
+    spy.restore();
+    done();
+  });
+});

--- a/packages/furo-fbp/test/fbp-fn-debugging.test.js
+++ b/packages/furo-fbp/test/fbp-fn-debugging.test.js
@@ -16,7 +16,7 @@ describe('fbp-fn-debugging.test', () => {
       <flow-bind>
         <template>
           <div id="hull">
-            <div id="sender" on-click="--data-received">sender</div>
+            <div id="sender" at-click="--data-received">sender</div>
             <div id="receiver" fn-click="--data-received">receiver</div>
           </div>
         </template>

--- a/packages/furo-fbp/test/flow-fn-bind.test.js
+++ b/packages/furo-fbp/test/flow-fn-bind.test.js
@@ -1,0 +1,52 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('flow-bind', () => {
+  let element;
+
+  let btn;
+  let div;
+
+  let host;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <flow-bind>
+            <template>
+              <button on-click="--clk"></button>
+              <div fn-done="--clk">x</div>
+            </template>
+          </flow-bind>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [, element] = testbind.parentNode.children;
+    await host.updateComplete;
+    await element.updateComplete;
+    [, , btn, div] = element.parentNode.children;
+    testbind;
+  });
+
+  it('should be a flow-bind', done => {
+    // keep this test on top, so you can recognize a wrong asignment
+    assert.equal(element.nodeName.toLowerCase(), 'flow-bind');
+    assert.equal(btn.nodeName.toLowerCase(), 'button');
+    assert.equal(div.nodeName.toLowerCase(), 'div');
+    done();
+  });
+
+  it('click should call done on div', done => {
+    assert.equal(div.innerText, 'x');
+    div.done = () => {
+      done();
+    };
+    btn.click();
+  });
+});

--- a/packages/furo-fbp/test/flow-fn-bind.test.js
+++ b/packages/furo-fbp/test/flow-fn-bind.test.js
@@ -18,7 +18,7 @@ describe('flow-bind', () => {
         <template>
           <flow-bind>
             <template>
-              <button on-click="--clk"></button>
+              <button at-click="--clk"></button>
               <div fn-done="--clk">x</div>
             </template>
           </flow-bind>

--- a/packages/furo-fbp/test/flow-fn-repeat.test.js
+++ b/packages/furo-fbp/test/flow-fn-repeat.test.js
@@ -1,0 +1,199 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert, expect } from '@esm-bundle/chai';
+
+import '../src/flow-repeat.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('flow-fn-repeat', () => {
+  let repeat;
+  let data;
+
+  beforeEach(async () => {
+    data = [
+      { a: 2, arr: [1, 2, 3] },
+      { a: 1, arr: [12, 2, 3] },
+      { a: 3, arr: [41, 2, 3] },
+      {
+        a: 23,
+        arr: [71, 2, 3],
+      },
+      { a: 14, arr: [1, 42, 3] },
+      { a: 35, arr: [13, 2, 3] },
+    ];
+
+    const testbind = await fixture(html`
+      <ul>
+        <flow-repeat fn-inject-items="--data" internal-wire="--inject">
+          <template>
+            <li>other node</li>
+            <li>
+              <b>neu</b>
+              <rep-item
+                fn-raw="--inject"
+
+                @-click="--xx"
+              ></rep-item>
+              <rep-item fn-index="--inject(*.index)" fn-yy="--xx"></rep-item>
+              <flow-repeat fn-inject-items="--inject(*.item.arr)">
+                <template>
+                  <div set-inner-text="--item"></div>
+                </template>
+              </flow-repeat>
+            </li>
+          </template>
+        </flow-repeat>
+      </ul>
+    `);
+    await testbind.updateComplete;
+
+    [repeat] = testbind.children;
+  });
+
+  it('should be a flow-repeat', done => {
+    // keep this test on top, so you can recognize a wrong asignment
+    assert.equal(repeat.nodeName.toLowerCase(), 'flow-repeat');
+    done();
+  });
+
+  it('should render the template x times', done => {
+    repeat.addEventListener('items-in-dom', e => {
+      expect(e.detail).to.equal(6);
+      done();
+    });
+    repeat.injectItems(data);
+  });
+
+  it('should only accept arrays in injectItems', () => {
+    repeat.injectItems('I am a String');
+    expect(repeat._insertedItems.length).to.equal(0);
+  });
+
+  it('select with index should trigger wires for select/deselect', done => {
+    repeat.addEventListener('items-in-dom', () => {
+      repeat._insertedItems[1].virtualElement._FBPAddWireHook(
+        '--itemSelected',
+        () => {
+          expect(repeat._insertedItems[1].virtualElement.nodeName).to.equal(
+            'EMPTY-FBP-NODE'
+          );
+        }
+      );
+      repeat._insertedItems[1].virtualElement._FBPAddWireHook(
+        '--itemDeSelected',
+        () => {
+          done();
+        }
+      );
+
+      repeat.select(1);
+      expect(repeat.selectedIndex).to.equal(1);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(2);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(3);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(4);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(5);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(0);
+    });
+
+    repeat.injectItems(data);
+  });
+
+  it('should be possible to navigate trough the items', done => {
+    repeat.addEventListener('items-in-dom', () => {
+      repeat.select(1);
+      expect(repeat.selectedIndex).to.equal(1);
+      repeat.selectNextIndex();
+      expect(repeat.selectedIndex).to.equal(2);
+      repeat.selectPreviousIndex();
+      expect(repeat.selectedIndex).to.equal(1);
+      repeat.selectPreviousIndex();
+      expect(repeat.selectedIndex).to.equal(0);
+      repeat.selectPreviousIndex();
+      expect(repeat.selectedIndex).to.equal(5);
+
+      done();
+    });
+
+    repeat.injectItems(data);
+  });
+
+  it('should trigger selected element/all elements with data', done => {
+    repeat.addEventListener('items-in-dom', () => {
+      repeat._insertedItems[0].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('First');
+        }
+      );
+      repeat._insertedItems[5].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('Last');
+          done();
+        }
+      );
+      repeat._insertedItems[1].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('Payload');
+        }
+      );
+      repeat._insertedItems[1].virtualElement._FBPAddWireHook(
+        '--triggerIndex',
+        w => {
+          expect(w).to.equal('Payload');
+        }
+      );
+
+      repeat.select(1);
+      repeat.triggerSelected('Payload');
+      repeat.triggerFirst('First');
+      repeat.triggerLast('Last');
+    });
+    repeat.injectItems(data);
+  });
+
+  it('should trigger all elements with data', done => {
+    repeat.addEventListener('items-in-dom', () => {
+      repeat._insertedItems[0].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('Payload');
+        }
+      );
+
+      repeat._insertedItems[1].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('Payload');
+        }
+      );
+
+      repeat._insertedItems[5].virtualElement._FBPAddWireHook(
+        '--trigger',
+        w => {
+          expect(w).to.equal('Payload');
+          done();
+        }
+      );
+
+      repeat.select(1);
+      repeat.triggerAll('Payload');
+    });
+    repeat.injectItems(data);
+  });
+
+  it('should clear the list', done => {
+    repeat.addEventListener('items-in-dom', e => {
+      expect(e.detail).to.equal(6);
+      repeat.clear();
+      expect(repeat._insertedItems.length).to.equal(0);
+      done();
+    });
+    repeat.injectItems(data);
+  });
+});

--- a/packages/furo-fbp/test/hooks-fn.test.js
+++ b/packages/furo-fbp/test/hooks-fn.test.js
@@ -17,24 +17,24 @@ describe('hooks-fn', () => {
     const testbind = await fixture(html`
       <flow-bind>
         <template>
-          <button id="btn" on-click="--clk"></button>
-          <div id="dd" fn-done="--clk" on-dummy="--clk">x</div>
+          <button id="btn" at-click="--clk"></button>
+          <div id="dd" fn-done="--clk" at-dummy="--clk">x</div>
           <div
             id="xx"
             fn-dummy="--clk"
             fn-dummy-camel="--clk"
             fn-subprop="--subProperty(*.b)"
-            on-firesub="^^subbubble(*.detail.ccc), ^subnonbubble(*.detail.eee), -^subhost(*.detail.ccc.xx)"
+            at-firesub="^^subbubble(*.detail.ccc), ^subnonbubble(*.detail.eee), -^subhost(*.detail.ccc.xx)"
           >
             dummy
           </div>
 
-          <button id="bubblebtn" on-click="--bubble"></button>
+          <button id="bubblebtn" at-click="--bubble"></button>
 
           <div
             id="bubble"
             fn-hit="--bubble"
-            on-hitted="((propp)),--raw(*), --subProperty(subproperty), --data(id), ^prop(prop),^fire, ^^testEvent,^^fireBubbleData(id), -^fire-on-host-with-data, -^fire-on-host-with-data(id),:STOP,:PREVENTDEFAULT"
+            at-hitted="((propp)),--raw(*), --subProperty(subproperty), --data(id), ^prop(prop),^fire, ^^testEvent,^^fireBubbleData(id), -^fire-at-host-with-data, -^fire-at-host-with-data(id),:STOP,:PREVENTDEFAULT"
             fn-sefl="oo"
           >
             dummy

--- a/packages/furo-fbp/test/hooks-fn.test.js
+++ b/packages/furo-fbp/test/hooks-fn.test.js
@@ -1,0 +1,200 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('hooks-fn', () => {
+  let host;
+  let btn;
+  let dd;
+  let xx;
+  let bubblebtn;
+  let parent;
+  let bubble;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <button id="btn" on-click="--clk"></button>
+          <div id="dd" fn-done="--clk" on-dummy="--clk">x</div>
+          <div
+            id="xx"
+            fn-dummy="--clk"
+            fn-dummy-camel="--clk"
+            fn-subprop="--subProperty(*.b)"
+            on-firesub="^^subbubble(*.detail.ccc), ^subnonbubble(*.detail.eee), -^subhost(*.detail.ccc.xx)"
+          >
+            dummy
+          </div>
+
+          <button id="bubblebtn" on-click="--bubble"></button>
+
+          <div
+            id="bubble"
+            fn-hit="--bubble"
+            on-hitted="((propp)),--raw(*), --subProperty(subproperty), --data(id), ^prop(prop),^fire, ^^testEvent,^^fireBubbleData(id), -^fire-on-host-with-data, -^fire-on-host-with-data(id),:STOP,:PREVENTDEFAULT"
+            fn-sefl="oo"
+          >
+            dummy
+          </div>
+
+          <script></script>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    parent = testbind.parentNode;
+    [, btn, dd, xx, bubblebtn, bubble] = testbind.parentNode.children;
+    await host.updateComplete;
+  });
+
+  it('should be a hooks', done => {
+    // keep this test on top, so you can recognize a wrong asignment
+    assert.equal(btn.id, 'btn');
+    assert.equal(xx.id, 'xx');
+    assert.equal(dd.id, 'dd');
+    assert.equal(bubblebtn.id, 'bubblebtn');
+    assert.equal(bubble.id, 'bubble');
+    done();
+  });
+
+  it('should filter subprops of details on refire the event with ^^subnonbubble(*.eee)', done => {
+    xx.addEventListener('subnonbubble', e => {
+      assert.equal(e.detail, 3);
+      done();
+    });
+
+    const customEvent = new Event('firesub', { composed: true, bubbles: true });
+    customEvent.detail = { eee: 3, ccc: 4 };
+    xx.dispatchEvent(customEvent);
+  });
+
+  it('should filter subprops of details on refire the event with ^^subbubble(*.ccc)', done => {
+    xx.parentNode.addEventListener('subbubble', e => {
+      assert.equal(e.detail, 4);
+      done();
+    });
+
+    const customEvent = new Event('firesub', { composed: true, bubbles: true });
+    customEvent.detail = { eee: 3, ccc: 4 };
+    xx.dispatchEvent(customEvent);
+  });
+
+  it('should filter subprops of details on refire the event with -^subhost(*.ccc)', done => {
+    host.addEventListener('subhost', e => {
+      assert.equal(e.detail.a, 2);
+      done();
+    });
+
+    const customEvent = new Event('firesub', { composed: true, bubbles: true });
+    customEvent.detail = { eee: 3, ccc: { xx: { a: 2 } } };
+    xx.dispatchEvent(customEvent);
+  });
+
+  it('should send sub properties of a wire', done => {
+    xx.subprop = data => {
+      assert.equal(data, 4);
+      done();
+    };
+    host.subproperty = { a: 3, b: 4 };
+
+    // eslint-disable-next-line func-names
+    bubble.hit = function () {
+      const customEvent = new Event('hitted', {
+        composed: true,
+        bubbles: true,
+      });
+      customEvent.detail = 3333;
+      this.dispatchEvent(customEvent);
+    };
+
+    bubblebtn.click();
+  });
+
+  it('click should bubble event', done => {
+    // element hat den event
+    parent.addEventListener('testEvent', e => {
+      assert.equal(host.propp, 3333);
+      assert.equal(e.detail, 3333);
+      done();
+    });
+
+    // eslint-disable-next-line func-names
+    bubble.hit = function () {
+      const customEvent = new Event('hitted', {
+        composed: true,
+        bubbles: true,
+      });
+      customEvent.detail = 3333;
+      this.dispatchEvent(customEvent);
+    };
+
+    bubblebtn.click();
+  });
+
+  it('using a nonexistent wire should register it and return length of 1', done => {
+    // text after clk should have changed
+    const r = host._FBPAddWireHook(
+      '--nonexist',
+      d => {
+        assert.equal(dd.innerText, 'x');
+        assert.equal(d, 33);
+        done();
+      },
+      true
+    );
+    assert.equal(r, 1);
+    host._FBPTriggerWire('--nonexist', 33);
+  });
+
+  it('hook should call callback BEFORE wire receivers are informed', done => {
+    // text after clk should have changed
+    host._FBPAddWireHook(
+      '--clk',
+      d => {
+        assert.equal(dd.innerText, 'x');
+        assert.equal(d, 0);
+        done();
+      },
+      true
+    );
+
+    assert.equal(dd.innerText, 'x');
+    dd.done = () => {
+      dd.innerText = 'done was called';
+    };
+    btn.click();
+  });
+
+  it('hook should call callback after wire receivers are informed', done => {
+    // text after clk should have changed
+    host._FBPAddWireHook('--clk', d => {
+      assert.equal(dd.innerText, 'done was called');
+      assert.equal(d, 0);
+      done();
+    });
+
+    assert.equal(dd.innerText, 'x');
+    dd.done = () => {
+      dd.innerText = 'done was called';
+    };
+    btn.click();
+  });
+
+  it('click should call done on div', done => {
+    assert.equal(dd.innerText, 'x');
+    dd.done = () => {
+      done();
+    };
+    btn.click();
+  });
+
+  it('triggering an nonexistent wire should have no effect', () => {
+    // text after clk should have changed
+    host._FBPTriggerWire('--nonexist', { a: 1 });
+    assert.equal(dd.innerText, 'x');
+  });
+});

--- a/packages/furo-fbp/test/hooks.test.js
+++ b/packages/furo-fbp/test/hooks.test.js
@@ -34,7 +34,7 @@ describe('hooks', () => {
           <div
             id="bubble"
             ƒ-hit="--bubble"
-            @-hitted="((propp)),--raw(*), --subProperty(subproperty), --data(id), ^prop(prop),^fire, ^^testEvent,^^fireBubbleData(id), -^fire-on-host-with-data, -^fire-on-host-with-data(id),:STOP,:PREVENTDEFAULT"
+            @-hitted="((propp)),--raw(*), --subProperty(subproperty), --data(id), ^prop(prop),^fire, ^^testEvent,^^fireBubbleData(id), -^fire-at-host-with-data, -^fire-at-host-with-data(id),:STOP,:PREVENTDEFAULT"
             ƒ-sefl="oo"
           >
             dummy

--- a/packages/furo-fbp/test/property-setting-fn.test.js
+++ b/packages/furo-fbp/test/property-setting-fn.test.js
@@ -17,8 +17,8 @@ describe('property-setting-fn', () => {
           <div id="hull">
             <div
               id="sender"
-              on-new-data="--data-received, --sub, --rawEvent(*), --rawSub(*.other.yyyyy.0), ((some.yyyyy))"
-              on-method-test="--method"
+              at-new-data="--data-received, --sub, --rawEvent(*), --rawSub(*.other.yyyyy.0), ((some.yyyyy))"
+              at-method-test="--method"
             >
               sender
             </div>

--- a/packages/furo-fbp/test/property-setting-fn.test.js
+++ b/packages/furo-fbp/test/property-setting-fn.test.js
@@ -1,0 +1,103 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('property-setting-fn', () => {
+  let element;
+  let host;
+  let receiver;
+  let sender;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <div id="hull">
+            <div
+              id="sender"
+              on-new-data="--data-received, --sub, --rawEvent(*), --rawSub(*.other.yyyyy.0), ((some.yyyyy))"
+              on-method-test="--method"
+            >
+              sender
+            </div>
+            <div
+              id="receiver"
+              set-prop="--data-received"
+              set-subprop="--sub(*.b)"
+              set-raw="--rawEvent(*.other)"
+              set-rawsub="--rawSub(*.a.2)"
+              fn-method-test="--method(*.sub)"
+            >
+              receiver
+            </div>
+          </div>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [, element] = testbind.parentNode.children;
+    receiver = element.querySelector('#receiver');
+    sender = element.querySelector('#sender');
+    await host.updateComplete;
+    await element.updateComplete;
+  });
+
+  it('should assign the correct elements', done => {
+    assert.equal(element.id, 'hull');
+    assert.equal(receiver.id, 'receiver');
+    assert.equal(sender.id, 'sender');
+    done();
+  });
+
+  it('should set the property prop of receiver to e.detail', done => {
+    const customEvent = new Event('new-data', {
+      composed: true,
+      bubbles: true,
+    });
+    customEvent.detail = { a: 1, b: 4 };
+    sender.dispatchEvent(customEvent);
+
+    assert.equal(receiver.prop.b, 4);
+    done();
+  });
+
+  it('should set the property subprop of receiver to e.detail.b', done => {
+    const customEvent = new Event('new-data', {
+      composed: true,
+      bubbles: true,
+    });
+    customEvent.detail = { a: 1, b: 4 };
+    sender.dispatchEvent(customEvent);
+    assert.equal(receiver.subprop, 4);
+    done();
+  });
+
+  it('should set the property raw of receiver from raw event', done => {
+    const customEvent = new Event('new-data', {
+      composed: true,
+      bubbles: true,
+    });
+    customEvent.detail = { a: 1, b: 4 };
+    customEvent.other = { xxxxx: 1, yyyyy: 4 };
+    sender.dispatchEvent(customEvent);
+    assert.equal(receiver.raw.yyyyy, 4);
+    done();
+  });
+
+  it('should send e.other and set e.other.yyyyy to receiver', done => {
+    receiver.methodTest = e => {
+      assert.equal(e, '----');
+      done();
+    };
+
+    const customEvent = new Event('method-test', {
+      composed: true,
+      bubbles: true,
+    });
+    customEvent.detail = { sub: '----' };
+    sender.dispatchEvent(customEvent);
+  });
+});

--- a/packages/furo-fbp/test/responder-test.js
+++ b/packages/furo-fbp/test/responder-test.js
@@ -1,0 +1,41 @@
+import { LitElement, html } from 'lit';
+import { FBP } from '../src/fbp.js';
+
+/**
+ * `responder-test`
+ *
+ * @customElement
+ * @appliesMixin FBP
+ */
+class ResponderTest extends FBP(LitElement) {
+  constructor() {
+    super();
+
+
+
+  }
+
+  firstUpdated(d) {
+    super.firstUpdated(d);
+  }
+
+  double(n){
+    return n*2;
+  }
+
+
+  render() {
+    // language=HTML
+    return html`
+      <!-- Add a style block here -->
+      <style>
+        :host {
+          display: block;
+        }
+      </style>
+       Hej, welcome
+    `;
+  }
+}
+
+window.customElements.define('responder-test', ResponderTest);

--- a/packages/furo-fbp/test/responder-test.js
+++ b/packages/furo-fbp/test/responder-test.js
@@ -23,6 +23,10 @@ class ResponderTest extends FBP(LitElement) {
     return n*2;
   }
 
+  tripple(n){
+    return n*3;
+  }
+
 
   render() {
     // language=HTML

--- a/packages/furo-fbp/test/responder.test.js
+++ b/packages/furo-fbp/test/responder.test.js
@@ -13,8 +13,12 @@ describe('responder', () => {
     const testbind = await fixture(html`
       <flow-bind>
         <template>
-          <responder-test id='calc' ƒ-double='--number' @-ƒ-double='--response' fn-double='--numberFN'
-                          on-fnret-double='--responseFN'></responder-test>
+          <responder-test
+            ƒ-double='--number'
+            @-ƒ-double='--response'
+            fn-double='--numberFN'
+            on-fnret-double='--responseFN'
+          ></responder-test>
         </template>
       </flow-bind>
     `)
@@ -28,11 +32,6 @@ describe('responder', () => {
 
   it('responder should be executed', done => {
 
-    element.addEventListener('fnret-double', (d) => {
-        console.log(d)
-      },
-    )
-
     host._FBPAddWireHook('--response', n => {
       assert.equal(n, 8)
       done()
@@ -44,13 +43,18 @@ describe('responder', () => {
 
 
   it('responder should be executed', done => {
-
     host._FBPAddWireHook('--responseFN', n => {
       assert.equal(n, 16)
       done()
     })
-
     host._FBPTriggerWire('--numberFN', 8)
+  })
 
+  it('Mixed', done => {
+    host._FBPAddWireHook('--responseFN', n => {
+      assert.equal(n, 16)
+      done()
+    })
+    host._FBPTriggerWire('--number', 8)
   })
 })

--- a/packages/furo-fbp/test/responder.test.js
+++ b/packages/furo-fbp/test/responder.test.js
@@ -1,0 +1,56 @@
+import { fixture, html } from '@open-wc/testing'
+import { assert } from '@esm-bundle/chai'
+
+import '../src/furo-catalog.js'
+import './responder-test.js'
+import '../src/flow-bind.js' // for testing with wires and hooks
+
+describe('responder', () => {
+  let element
+  let host
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <responder-test id='calc' ƒ-double='--number' @-ƒ-double='--response' fn-double='--numberFN'
+                          on-fnret-double='--responseFN'></responder-test>
+        </template>
+      </flow-bind>
+    `)
+    await testbind.updateComplete
+    host = testbind._host;
+    [, element] = testbind.parentNode.children
+    await host.updateComplete
+    await element.updateComplete
+  })
+
+
+  it('responder should be executed', done => {
+
+    element.addEventListener('fnret-double', (d) => {
+        console.log(d)
+      },
+    )
+
+    host._FBPAddWireHook('--response', n => {
+      assert.equal(n, 8)
+      done()
+    })
+
+    host._FBPTriggerWire('--number', 4)
+
+  })
+
+
+  it('responder should be executed', done => {
+
+    host._FBPAddWireHook('--responseFN', n => {
+      assert.equal(n, 16)
+      done()
+    })
+
+    host._FBPTriggerWire('--numberFN', 8)
+
+  })
+})

--- a/packages/furo-fbp/test/responder.test.js
+++ b/packages/furo-fbp/test/responder.test.js
@@ -17,7 +17,7 @@ describe('responder', () => {
             ƒ-double='--number'
             @-ƒ-double='--response'
             fn-double='--numberFN'
-            on-fnret-double='--responseFN'
+            at-fnret-double='--responseFN'
           ></responder-test>
         </template>
       </flow-bind>

--- a/packages/furo-fbp/test/spreading-fn.test.js
+++ b/packages/furo-fbp/test/spreading-fn.test.js
@@ -15,7 +15,7 @@ describe('spreading', () => {
       <flow-bind>
         <template>
           <div id="hull">
-            <div id="sender" on-new-data="--data-received">sender</div>
+            <div id="sender" at-new-data="--data-received">sender</div>
             <div id="receiver" fn-spread="--data-received">receiver</div>
           </div>
         </template>

--- a/packages/furo-fbp/test/spreading-fn.test.js
+++ b/packages/furo-fbp/test/spreading-fn.test.js
@@ -1,0 +1,52 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('spreading', () => {
+  let element;
+  let host;
+  let receiver;
+  let sender;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <div id="hull">
+            <div id="sender" on-new-data="--data-received">sender</div>
+            <div id="receiver" fn-spread="--data-received">receiver</div>
+          </div>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [, element] = testbind.parentNode.children;
+    receiver = element.querySelector('#receiver');
+    sender = element.querySelector('#sender');
+    await host.updateComplete;
+    await element.updateComplete;
+  });
+
+  it('should assign the correct elements', done => {
+    assert.equal(element.id, 'hull');
+    assert.equal(receiver.id, 'receiver');
+    assert.equal(sender.id, 'sender');
+    done();
+  });
+
+  it('should spread array to receiver.spread()', done => {
+    // methods with multiple arguments can receive wires with an argument array.
+
+    receiver.spread = (a, b) => {
+      receiver.c = a * b;
+    };
+    const customEvent = new Event('new-data');
+    customEvent.detail = [4, 6];
+    sender.dispatchEvent(customEvent);
+    assert.equal(receiver.c, 24);
+    done();
+  });
+});

--- a/packages/furo-fbp/test/subpath-fn.test.js
+++ b/packages/furo-fbp/test/subpath-fn.test.js
@@ -1,0 +1,97 @@
+import { fixture, html } from '@open-wc/testing';
+import { assert } from '@esm-bundle/chai';
+
+import '../src/furo-catalog.js';
+import '../src/flow-bind.js'; // for testing with wires and hooks
+
+describe('subpath', () => {
+  let element;
+  let host;
+  let receiver;
+  let sender;
+
+  beforeEach(async () => {
+    const testbind = await fixture(html`
+      <flow-bind>
+        <template>
+          <div id="hull">
+            <div
+              id="sender"
+              on-new-data="--fromSender(*.detail.a.b.c), --onReceiver"
+              on-sendarray="--sendArray(*.detail.a.b.1.x.0)"
+            >
+              sender
+            </div>
+            <div
+              id="receiver"
+              fn-test="--fromSender"
+              fn-onreceiver="--onReceiver(*.a.b)"
+              fn-onreceiverarray="--onReceiver(*.a.b.2)"
+              fn-sendarray="--sendArray"
+            >
+              receiver
+            </div>
+          </div>
+        </template>
+      </flow-bind>
+    `);
+    await testbind.updateComplete;
+    host = testbind._host;
+    [, element] = testbind.parentNode.children;
+    receiver = element.querySelector('#receiver');
+    sender = element.querySelector('#sender');
+    await host.updateComplete;
+    await element.updateComplete;
+  });
+
+  it('should assign the correct elements', done => {
+    assert.equal(element.id, 'hull');
+    assert.equal(receiver.id, 'receiver');
+    assert.equal(sender.id, 'sender');
+    done();
+  });
+
+  it('should send subpath of event', done => {
+    receiver.test = e => {
+      assert.equal(e, 3);
+      done();
+    };
+
+    const customEvent = new Event('new-data');
+    customEvent.detail = { a: { b: { c: 3 } } };
+    sender.dispatchEvent(customEvent);
+  });
+
+  it('should pass subpath on e.detail.a.b => (*.a.b)', done => {
+    receiver.onreceiver = e => {
+      assert.equal(e.c, 3);
+      done();
+    };
+
+    const customEvent = new Event('new-data');
+    customEvent.detail = { a: { b: { c: 3 } } };
+    sender.dispatchEvent(customEvent);
+  });
+
+  it('should pass subpath  Array on e.detail.a.b => (*.a.b.2)', done => {
+    receiver.onreceiverarray = e => {
+      assert.equal(e, 10);
+      done();
+    };
+
+    const customEvent = new Event('new-data');
+    customEvent.detail = { a: { b: [8, 9, 10, 11] } };
+    sender.dispatchEvent(customEvent);
+  });
+
+  it('should send subpath  Array on e.detail.a.b.1.x.0 => (*.a.b.1.x.0)', done => {
+    receiver.sendarray = e => {
+      assert.equal(e, 9);
+      done();
+    };
+
+    const customEvent = new Event('sendarray');
+    customEvent.detail = { a: { b: [8, { x: [9, 10] }, 10, 11] } };
+    sender.dispatchEvent(customEvent);
+  });
+});

--- a/packages/furo-fbp/test/subpath-fn.test.js
+++ b/packages/furo-fbp/test/subpath-fn.test.js
@@ -17,8 +17,8 @@ describe('subpath', () => {
           <div id="hull">
             <div
               id="sender"
-              on-new-data="--fromSender(*.detail.a.b.c), --onReceiver"
-              on-sendarray="--sendArray(*.detail.a.b.1.x.0)"
+              at-new-data="--fromSender(*.detail.a.b.c), --onReceiver"
+              at-sendarray="--sendArray(*.detail.a.b.1.x.0)"
             >
               sender
             </div>


### PR DESCRIPTION
As we know, a lot of users have problems, to type the florin ƒ to wire the components. 
Therefore , we come now with a set of alternatives.

```
  @-     =>    at-
  ƒ-      =>    fn-
  ƒ-.      =>    set-
  @-ƒ-      =>    on-fnret-
```

- The new symbols can be mixed with the old ones :-)
- Test coverage of the symbols is at 100% 
- fbp is a little bit faster now (even with the additional symbols)

```html
<button at-click="--wire">play</button>
<video src="..." fn-play="--wire"></video>
```
