### PR TITLE
feat: FuroFeatureToggle can accept new data-furo-toggle-custom attribute

### DIFF
--- a/packages/furo-framework/src/FuroFeatureToggler/FuroFeatureToggle.js
+++ b/packages/furo-framework/src/FuroFeatureToggler/FuroFeatureToggle.js
@@ -25,6 +25,8 @@ const keystore = {};
  * - `data-furo-toggle-disable` Adds a disabled attribute to the element on true state of the key, removes the attribute on false state
  * - `data-furo-toggle-enable` Removes a disabled attribute from the element on true state of the key, adds the attribute on false state
  *
+ * - `data-furo-toggle-custom-add` Adds the custom attribute to the element on true state of the key, removes the attribute on false state
+ * - `data-furo-toggle-custom-remove` Removes the custom attribute from the element on true state of the key, adds the attribute on false state
  *
  * ## Example usage:
  * ### js
@@ -70,6 +72,16 @@ const keystore = {};
  *  show:
  *  <div data-furo-toggle-show='feature.key'>
  *   The hidden attribute will be removed when the key state is true, otherwise the hidden attribute will be set.
+ *  </div>
+ *
+ *  custom add:
+ *  <div data-furo-toggle-custom-add='feature.key, ATTRIBUTE, VALUE'>
+ *   Div will get a custom attribute when the key state is true, otherwise the custom attribute will be removed.
+ *  </div>
+ *
+ *  custom remove:
+ *  <div data-furo-toggle-custom-remove='feature.key, ATTRIBUTE, VALUE'>
+ *   The custom attribute will be removed when the key state is true, otherwise the custom attribute will be set.
  *  </div>
  *
  * ```
@@ -133,6 +145,36 @@ export class FuroFeatureToggle {
         keystore[key].registerEnabler(e);
       }
     );
+
+    // register all custom add toggle attributes
+    Array.from(root.querySelectorAll('*[data-furo-toggle-custom-add]')).forEach(
+      e => {
+        const values = e.dataset.furoToggleCustomAdd.split(',');
+        const key = values[0];
+        let data = '';
+        if (values.length > 1) {
+          // add custom data to key
+          data = values.slice(1).join(",").replaceAll(' ', '')
+        }
+        FuroFeatureToggle._mustKey(key, data);
+        keystore[key].registerCustomAdder(e);
+      }
+    );
+
+    // register all custom add toggle attributes
+    Array.from(root.querySelectorAll('*[data-furo-toggle-custom-remove]')).forEach(
+      e => {
+        const values = e.dataset.furoToggleCustomRemove.split(',');
+        const key = values[0];
+        let data = '';
+        if (values.length > 1) {
+          // add custom data to key
+          data = values.slice(1).join(",").replaceAll(' ', '')
+        }
+        FuroFeatureToggle._mustKey(key, data);
+        keystore[key].registerCustomRemover(e);
+      }
+    );
   }
 
   /**
@@ -184,10 +226,13 @@ export class FuroFeatureToggle {
    * @param key {String} The key of a feature.
    * @private
    */
-  static _mustKey(key) {
+  static _mustKey(key, data = undefined) {
     if (keystore[key] === undefined) {
       // create with a falsy initial state
       keystore[key] = new KeyState(false);
+    }
+    if (data !== undefined) {
+      keystore[key]._data = data;
     }
   }
 }

--- a/packages/furo-framework/src/FuroFeatureToggler/KeyState.js
+++ b/packages/furo-framework/src/FuroFeatureToggler/KeyState.js
@@ -11,6 +11,14 @@ export class KeyState {
      */
     this._state = initialState;
     // we store a ref to the removers, appender,... here
+
+    /**
+     * Additional data
+     * Used for custom-add and custom-remove
+     * @type {{}}
+     * @private
+     */
+    this._data = '';
     /**
      * @private
      */
@@ -35,6 +43,14 @@ export class KeyState {
      * @private
      */
     this._enablers = [];
+    /**
+     * @private
+     */
+    this._customAdders = [];
+    /**
+     * @private
+     */
+    this._customRemovers = [];
     /**
      * @private
      */
@@ -131,6 +147,42 @@ export class KeyState {
   }
 
   /**
+   * @private
+   * @param element {domnode} original dom node
+   */
+  registerCustomAdder(element) {
+    this._customAdders.push(element);
+    // apply the initial state
+    let values = '';
+    if (this._data.length) {
+      values = this._data.split(',')
+    }
+    if (this._state === true) {
+      element.setAttribute(values[0], values[1]);
+    } else {
+      element.removeAttribute(values[0]);
+    }
+  }
+
+  /**
+   * @private
+   * @param element {domnode} original dom node
+   */
+  registerCustomRemover(element) {
+    this._customRemovers.push(element);
+    // apply the initial state
+    let values = '';
+    if (this._data.length) {
+      values = this._data.split(',')
+    }
+    if (this._state !== true) {
+      element.setAttribute(values[0], values[1]);
+    } else {
+      element.removeAttribute(values[0]);
+    }
+  }
+
+  /**
    * register a callback on a key
    * @param cb {function(boolean)}
    * @private
@@ -195,6 +247,30 @@ export class KeyState {
           element.setAttribute('disabled', '');
         } else {
           element.removeAttribute('disabled');
+        }
+      });
+
+      this._customAdders.forEach(element => {
+        let values = '';
+        if (this._data.length) {
+          values = this._data.split(',')
+        }
+        if (this._state === true) {
+          element.setAttribute(values[0], values[1]);
+        } else {
+          element.removeAttribute(values[0]);
+        }
+      });
+
+      this._customRemovers.forEach(element => {
+        let values = '';
+        if (this._data.length) {
+          values = this._data.split(',')
+        }
+        if (this._state !== true) {
+          element.setAttribute(values[0], values[1]);
+        } else {
+          element.removeAttribute(values[0]);
         }
       });
 


### PR DESCRIPTION
- `data-furo-toggle-custom-add` Adds the custom attribute to the element on true state of the key, removes the attribute on false state
- `data-furo-toggle-custom-remove` Removes the custom attribute from the element on true state of the key, adds the attribute on false state

https://github.com/eclipse/eclipsefuro-web/issues/67