### PR TITLE
fix: [open-models] use .label suffix for labels

### DIFF
--- a/packages/furo-open-models/src/FieldNode.ts
+++ b/packages/furo-open-models/src/FieldNode.ts
@@ -429,7 +429,9 @@ export abstract class FieldNode {
    * Returns the formated label using the `OPEN_MODELS_OPTIONS.labelFormatter`
    */
   get __label(): string {
-    return OPEN_MODELS_OPTIONS.labelFormatter(this.__getBaseName());
+    return OPEN_MODELS_OPTIONS.labelFormatter(
+      `${this.__getBaseName()}.label`,
+      );
   }
 
   /**

--- a/packages/furo-open-models/test/unit_tests/placeholder.label.aria.test.ts
+++ b/packages/furo-open-models/test/unit_tests/placeholder.label.aria.test.ts
@@ -6,8 +6,8 @@ describe('Placeholders and labels', () => {
     const id = new Identifier({ id: 'init' });
     id.id = 'stringliteral';
     expect(id.fatString.attributes.__label).equal(
-      'FURO_TYPE_IDENTIFIER_FAT_STRING_ATTRIBUTES',
+      'FURO_TYPE_IDENTIFIER_FAT_STRING_ATTRIBUTES_LABEL',
     );
-    expect(id.fatString.__label).equal('FURO_TYPE_IDENTIFIER_FAT_STRING');
+    expect(id.fatString.__label).equal('FURO_TYPE_IDENTIFIER_FAT_STRING_LABEL');
   });
 });

--- a/packages/furo-open-models/test/unit_tests/primitives.ANY.test.ts
+++ b/packages/furo-open-models/test/unit_tests/primitives.ANY.test.ts
@@ -124,10 +124,10 @@ describe('primitives ANY type', () => {
     const id = new Identifier(initData[0]);
 
     expect(id.bookingCenter.__label).to.equal(
-      'FURO_TYPE_IDENTIFIER_BOOKING_CENTER',
+      'FURO_TYPE_IDENTIFIER_BOOKING_CENTER_LABEL',
     );
     expect((id.any.value as Identifier).bookingCenter.__label).to.equal(
-      'FURO_TYPE_IDENTIFIER_BOOKING_CENTER',
+      'FURO_TYPE_IDENTIFIER_BOOKING_CENTER_LABEL',
     );
   });
 

--- a/packages/furo-open-models/test/unit_tests/primitives.ARRAY.test.ts
+++ b/packages/furo-open-models/test/unit_tests/primitives.ARRAY.test.ts
@@ -97,7 +97,7 @@ describe('primitives ARRAY type', () => {
     const id = new Identifier(initData[1]);
 
     expect(id.repeatedDecimal.value[1].value.__label).to.eql(
-      'FURO_TYPE_IDENTIFIER_REPEATED_DECIMAL_VALUE',
+      'FURO_TYPE_IDENTIFIER_REPEATED_DECIMAL_VALUE_LABEL',
     );
   });
   it('must deeply generate the ARRAYS<something> from code', async () => {

--- a/packages/furo-open-models/test/unit_tests/recursion.test.ts
+++ b/packages/furo-open-models/test/unit_tests/recursion.test.ts
@@ -145,9 +145,9 @@ describe('Recursion', () => {
     expect(
       tree.recursion.value!.recursion.value!.recursion.value!.displayName
         .__label,
-    ).equal('FURO_TYPE_TREE_DISPLAY_NAME');
+    ).equal('FURO_TYPE_TREE_DISPLAY_NAME_LABEL');
     expect(tree.recursion.value!.recursion.value!.recursion.__label).equal(
-      'FURO_TYPE_TREE_RECURSION',
+      'FURO_TYPE_TREE_RECURSION_LABEL',
     );
     expect(tree.displayName.__fieldPath).equal('display_name');
     expect(
@@ -157,6 +157,6 @@ describe('Recursion', () => {
     expect(
       tree.recursion.value!.recursion.value!.recursion.value!.displayName
         .__label,
-    ).equal('FURO_TYPE_TREE_DISPLAY_NAME');
+    ).equal('FURO_TYPE_TREE_DISPLAY_NAME_LABEL');
   });
 });


### PR DESCRIPTION
Label translations have the same behaviour like placeholders and descriptions